### PR TITLE
feat: add serialisation and deserialize traits to indexes

### DIFF
--- a/src/index/flat.rs
+++ b/src/index/flat.rs
@@ -1,10 +1,13 @@
 use crate::{Vector, VectorIndex, SearchResult, cosine_similarity};
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug)]
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FlatIndex {
     pub dim: usize,
     pub data: Vec<Vector>
 }
+
 impl FlatIndex {
     pub fn new(dim: usize, data: Vec<Vector>) -> Self {
         Self { dim, data }
@@ -57,4 +60,48 @@ impl VectorIndex for FlatIndex {
     fn dimension(&self) -> usize {
         self.dim
     }
+}
+
+#[test]
+fn test_serialization_deserialization() {
+    use serde_json;
+    
+    // Create a FlatIndex with some data
+    let vectors = vec![
+        Vector { id: 1, values: vec![1.0, 0.0, 0.0] },
+        Vector { id: 2, values: vec![0.0, 1.0, 0.0] },
+        Vector { id: 3, values: vec![0.0, 0.0, 1.0] },
+    ];
+    let flat_index = FlatIndex::new(3, vectors);
+    
+    // Serialize to JSON
+    let serialized = serde_json::to_string(&flat_index).expect("Serialization should work");
+    
+    // Deserialize from JSON
+    let deserialized: FlatIndex = serde_json::from_str(&serialized).expect("Deserialization should work");
+    
+    // Verify the deserialized index has the same properties
+    assert_eq!(deserialized.len(), 3);
+    assert_eq!(deserialized.dimension(), 3);
+    assert!(!deserialized.is_empty());
+    
+    // Verify we can retrieve vectors by ID
+    assert!(deserialized.get_vector(1).is_some());
+    assert!(deserialized.get_vector(2).is_some());
+    assert!(deserialized.get_vector(3).is_some());
+    
+    // Verify search works on the deserialized index
+    let query = vec![1.1, 0.1, 0.1];
+    let results = deserialized.search(&query, 2);
+    assert_eq!(results.len(), 2);
+    
+    // Results should be sorted by score (highest first)
+    for i in 1..results.len() {
+        assert!(results[i-1].score >= results[i].score);
+    }
+    
+    // The first result should be the most similar vector (ID 1)
+    assert_eq!(results[0].id, 1);
+    // Note: cosine similarity might not be exactly 1.0 due to floating point precision
+    assert!(results[0].score > 0.99);
 }

--- a/src/index/hash.rs
+++ b/src/index/hash.rs
@@ -1,8 +1,10 @@
 
+use serde::{Deserialize, Serialize};
+
 use crate::{Vector, VectorIndex, SearchResult, cosine_similarity};
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HashIndex {
     pub dim: usize,
     pub data: HashMap<u64, Vector>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,20 +4,86 @@ pub use index::flat::FlatIndex;
 pub use index::hash::HashIndex;
 pub use index::hnsw::HNSWIndex;
 
+use serde::{Serialize, Deserialize};
+
 pub const DEFAULT_VECTOR_DIMENSION: usize = 768;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Vector {
     pub id: u64,
     pub values: Vec<f64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
     pub id: u64,
     pub score: f64,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub enum VectorIndexWrapper {
+    Flat(FlatIndex),
+    Hash(HashIndex),
+    HNSW(HNSWIndex),
+}
+
+impl VectorIndex for VectorIndexWrapper {
+    fn add(&mut self, vector: Vector) -> Result<(), String> {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.add(vector),
+            VectorIndexWrapper::Hash(index) => index.add(vector),
+            VectorIndexWrapper::HNSW(index) => index.add(vector),  
+        }
+    }
+
+    fn delete(&mut self, id: u64) -> Result<(), String> {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.delete(id),
+            VectorIndexWrapper::Hash(index) => index.delete(id),
+            VectorIndexWrapper::HNSW(index) => index.delete(id),
+        }
+    }
+
+    fn search(&self, query: &[f64], k: usize) -> Vec<SearchResult> {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.search(query, k),
+            VectorIndexWrapper::Hash(index) => index.search(query, k),
+            VectorIndexWrapper::HNSW(index) => index.search(query, k),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.len(),
+            VectorIndexWrapper::Hash(index) => index.len(),
+            VectorIndexWrapper::HNSW(index) => index.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.is_empty(),
+            VectorIndexWrapper::Hash(index) => index.is_empty(),
+            VectorIndexWrapper::HNSW(index) => index.is_empty(),
+        }
+    }
+
+    fn get_vector(&self, id: u64) -> Option<&Vector> {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.get_vector(id),
+            VectorIndexWrapper::Hash(index) => index.get_vector(id),
+            VectorIndexWrapper::HNSW(index) => index.get_vector(id),
+        }
+    }
+
+    fn dimension(&self) -> usize {
+        match self {
+            VectorIndexWrapper::Flat(index) => index.dimension(),
+            VectorIndexWrapper::Hash(index) => index.dimension(),
+            VectorIndexWrapper::HNSW(index) => index.dimension(),
+        }
+    }
+}
 pub trait VectorIndex {
     fn add(&mut self, vector: Vector) -> Result<(), String>;
     fn delete(&mut self, id: u64) -> Result<(), String>;
@@ -97,8 +163,38 @@ mod tests {
         let results = store.search(&query, 2);
         
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].id, 0); // Should match the first vector
-        assert!((results[0].score - 1.0).abs() < 1e-10); // Perfect similarity
+        assert_eq!(results[0].id, 0);
+        assert!((results[0].score - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_vector_index_wrapper_serialization() {
+        use serde_json;
+        
+        // Test FlatIndex wrapper
+        let vectors = vec![
+            Vector { id: 1, values: vec![1.0, 0.0, 0.0] },
+            Vector { id: 2, values: vec![0.0, 1.0, 0.0] },
+        ];
+        let flat_index = FlatIndex::new(3, vectors);
+        let wrapper = VectorIndexWrapper::Flat(flat_index);
+        
+        // Serialize wrapper
+        let serialized = serde_json::to_string(&wrapper).expect("Serialization should work");
+        
+        // Deserialize wrapper
+        let deserialized: VectorIndexWrapper = serde_json::from_str(&serialized).expect("Deserialization should work");
+        
+        // Verify the deserialized wrapper works
+        assert_eq!(deserialized.len(), 2);
+        assert_eq!(deserialized.dimension(), 3);
+        assert!(!deserialized.is_empty());
+        
+        // Test search through the wrapper
+        let query = vec![1.1, 0.1, 0.1];
+        let results = deserialized.search(&query, 1);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, 1);
     }
 
 }


### PR DESCRIPTION
The PR adds serialisation and deserialisation to indices. 
Note that HNSW doesn't support these traits, thus needs a re-build approach from values. 